### PR TITLE
fix: ship a cjs bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "url": "git+https://github.com/nextcloud-libraries/timezones.git"
   },
   "type": "module",
-  "main": "dist/index.mjs",
+  "main": "dist/index.cjs",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
     },
     "./resources/timezones/zones.json": "./resources/timezones/zones.json"
   },

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,6 +8,7 @@ import { createLibConfig } from '@nextcloud/vite-config'
 export default createLibConfig({
 	index: 'src/index.js',
 }, {
+	libraryFormats: ['es', 'cjs'],
 	config: {
 		test: {
 			setupFiles: [


### PR DESCRIPTION
Unfortunately, a cjs bundle is still required by some tools to work out of the box, e.g. Jest.