### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 1.0.0 - 2025-08-25
+### Breaking changes
+The format of `zones.json` received a major overhaul.
+Please adjust your code accordingly if you import or parse `zones.json`.
+1. The aliases object is now mapping each alias directly to the actual time zone name (instead of
+   having a nested `aliasTo` key).
+2. Time zone coordinates (latitude and longitude) are not included anymore.
+### Features
+- Optimize alias format in zones.json (BREAKING!)
+### Fixes
+- Update and fix update-zones.py
+- Update timezones data
+- Update vulnerable dependencies
+
 ## 0.2.0 - 2025-04-22
 ## Features
 - Migrate code to Typescript

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nextcloud/timezones",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nextcloud/timezones",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "ical.js": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nextcloud/timezones",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "A small library containing common time zone logic and data",
   "homepage": "https://github.com/nextcloud-libraries/timezones",
   "bugs": {


### PR DESCRIPTION
Fix #70 

# Changelog

## 1.0.0 - 2025-08-25
### Breaking changes
The format of `zones.json` received a major overhaul.
Please adjust your code accordingly if you import or parse `zones.json`.
1. The aliases object is now mapping each alias directly to the actual time zone name (instead of
   having a nested `aliasTo` key).
2. Time zone coordinates (latitude and longitude) are not included anymore.
### Features
- Optimize alias format in zones.json (BREAKING!)
### Fixes
- Update and fix update-zones.py
- Update timezones data
- Update vulnerable dependencies